### PR TITLE
Make pylint-config-hooks available in version 1.9

### DIFF
--- a/pre-commit-hooks.yaml
+++ b/pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: pylint
+    name: pylint
+    entry: pylint
+    language: python
+    types: [python]


### PR DESCRIPTION
* pylint-config-hooks is now available for the version 1.9 branch
* this is because it allows projects that must use python2 to use the --py3k option to inspect python2/3 compatibility issues to set their repositories up for pre-commit

https://github.com/PyCQA/pylint/issues/3485

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description

* pylint-config-hooks is now available for the version 1.9 branch
* this is because it allows projects that must use python2 to use the --py3k option to inspect python2/3 compatibility issues to set their repositories up for pre-commit


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #3485

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #3485

-->
